### PR TITLE
In memstck_malloc: Make sure that the byte after the allocated memory is 0

### DIFF
--- a/arch/X86_64/stack.c
+++ b/arch/X86_64/stack.c
@@ -15,6 +15,7 @@ void* memstck_malloc(size_t bytes)
     void* pointer = (void*)MemStack;
 
     MemStack += bytes + 1;
+    ((char*)pointer)[bytes] = 0;
 
     return pointer;
 }


### PR DESCRIPTION
This will work as a security feature, especially for strings.